### PR TITLE
ZEN-5809 - Portfolio demo not working properly

### DIFF
--- a/portfolio/README.md
+++ b/portfolio/README.md
@@ -16,9 +16,9 @@ This demo application uses WebSocket to update stock price information in real-t
 5. Navigate to /stock-trading-service/build/install/stock-trading-service/bin. Here you can find for Linux Distribuition/MacOS a script "stock-trading-service" and for Windows a bat "stock-trading-service.bat";
 6. Run the script/bat that fits your environmnet by doing "./stock-trading-service" or "stock-trading-service.bat";
 7. If your ActiveMQ is **NOT** listening to tcp://localhost:61616 you will have to give the script as the first parameter the URL that your ActiveMQ is listening to ex: "./stock-trading-service tcp://{ACTIVEMQ.IP}:{ACTIVEMQ.PORT}" .Now the ticker that fetched and post the stock data has successfully started!;
-8. Navigate to ~/demos/portfolio/portfolio-web/ and run *npm install* to resolve needed dependencie;
+8. Navigate to ~/demos/portfolio/portfolio-web/ and run **npm install** to resolve needed dependencie;
 9. If your gateway is **NOT** accepting JMS connections on "ws://localhost:8000/jms" you will have to edit this file: ~/demos/portfolio/portfolio-web/server.js. You have to edit line 3 : "uri: 'localhost' to url: '"'{GATEWAY.IP}';
-10. Now in ~/demos/portfolio/portfolio-web/ run "node server.js";
+10. Now in ~/demos/portfolio/portfolio-web/ run **node server.js**;
 11. Now you are done and you can access either localhost:3000 or {GATEWAY.IP}:3000!
  
 To start building your own application with Kaazing Websocket Gateway, visit our [Getting Started](https://kaazing.com/getting-started/) page. </br>

--- a/portfolio/README.md
+++ b/portfolio/README.md
@@ -7,11 +7,11 @@ This demo application uses WebSocket to update stock price information in real-t
 
 To start this demo follow these steps:
 
-*Prerequisite is that you have the Kaazing Websocket Gateway and ActiveMQ up and running (more information [here](https://kaazing.com/doc/5.0/about/setup-guide/index.html))* 
+**Prerequisite is that you have the Kaazing Websocket Gateway and ActiveMQ up and running (more information [here](https://kaazing.com/doc/5.0/about/setup-guide/index.html))**
 
 1. Install gradle folow the steps [here](https://gradle.org/gradle-download/?_ga=1.147510451.589111043.1485507259);
-2. Install NodeJS for Linux go [here](https://nodejs.org/en/download/package-manager/), For Windows and use the installers [here](https://nodejs.org/en/download/) *You need both NodeJS and NPM*
-3. Navigate in the terminal/command line to where you cloned the demos and to the /portfolio folder (ex: ~/demos/portfolio);
+2. Install NodeJS for Linux go [here](https://nodejs.org/en/download/package-manager/), For Windows and MacOS use the installers [here](https://nodejs.org/en/download/) **You need both NodeJS and NPM**
+3. Navigate in the terminal/command line to where you cloned the kaazing demos repository and to the /portfolio folder (ex: ~/demos/portfolio);
 4. Navigate to ~/demos/portfolio/stock-trading-service/ and run *gradle installDist*;
 5. Navigate to /stock-trading-service/build/install/stock-trading-service/bin. Here you can find for Linux Distribuition/MacOS a script "stock-trading-service" and for Windows a bat "stock-trading-service.bat";
 6. Run the script/bat that fits your environmnet by doing "./stock-trading-service" or "stock-trading-service.bat";

--- a/portfolio/README.md
+++ b/portfolio/README.md
@@ -4,6 +4,23 @@ This demo application uses WebSocket to update stock price information in real-t
 
 ![Portfolio demo](Portfolio-app.png "Xignite demo")
 
+
+To start this demo follow these steps:
+
+*Prerequisite is that you have the Kaazing Websocket Gateway and ActiveMQ up and running (more information [here](https://kaazing.com/doc/5.0/about/setup-guide/index.html))* 
+
+1. Install gradle folow the steps [here](https://gradle.org/gradle-download/?_ga=1.147510451.589111043.1485507259);
+2. Install NodeJS for Linux go [here](https://nodejs.org/en/download/package-manager/), For Windows and use the installers [here](https://nodejs.org/en/download/) *You need both NodeJS and NPM*
+3. Navigate in the terminal/command line to where you cloned the demos and to the /portfolio folder (ex: ~/demos/portfolio);
+4. Navigate to ~/demos/portfolio/stock-trading-service/ and run *gradle installDist*;
+5. Navigate to /stock-trading-service/build/install/stock-trading-service/bin. Here you can find for Linux Distribuition/MacOS a script "stock-trading-service" and for Windows a bat "stock-trading-service.bat";
+6. Run the script/bat that fits your environmnet by doing "./stock-trading-service" or "stock-trading-service.bat";
+7. If your ActiveMQ is *NOT* listening to tcp://localhost:61616 you will have to give the script as the first parameter the URL that your ActiveMQ is listening to ex: "./stock-trading-service tcp://{ACTIVEMQ.IP}:{ACTIVEMQ.PORT}" .Now the ticker that fetched and post the stock data has successfully started!;
+8. Navigate to ~/demos/portfolio/portfolio-web/ and run *npm install* to resolve needed dependencie;
+9. If your gateway is *NOT* accepting JMS connections on "ws://localhost:8000/jms" you will have to edit this file: ~/demos/portfolio/portfolio-web/server.js. You have to edit line 3 : "uri: 'localhost' to url: '"'{GATEWAY.IP}';
+10. Now in ~/demos/portfolio/portfolio-web/ run "node server.js";
+11. Now you are done and you can access either localhost:3000 or {GATEWAY.IP}:3000!
+ 
 To start building your own application with Kaazing Websocket Gateway, visit our [Getting Started](https://kaazing.com/getting-started/) page. </br>
 
 Please [Contact Us](https://kaazing.com/contact/) for more information.

--- a/portfolio/README.md
+++ b/portfolio/README.md
@@ -5,19 +5,19 @@ This demo application uses WebSocket to update stock price information in real-t
 ![Portfolio demo](Portfolio-app.png "Xignite demo")
 
 
-To start this demo follow these steps:
+#To start this demo follow these steps:
 
 **Prerequisite is that you have the Kaazing Websocket Gateway and ActiveMQ up and running (more information [here](https://kaazing.com/doc/5.0/about/setup-guide/index.html))**
 
 1. Install gradle folow the steps [here](https://gradle.org/gradle-download/?_ga=1.147510451.589111043.1485507259);
 2. Install NodeJS for Linux go [here](https://nodejs.org/en/download/package-manager/), For Windows and MacOS use the installers [here](https://nodejs.org/en/download/) **You need both NodeJS and NPM**
 3. Navigate in the terminal/command line to where you cloned the kaazing demos repository and to the /portfolio folder (ex: ~/demos/portfolio);
-4. Navigate to ~/demos/portfolio/stock-trading-service/ and run *gradle installDist*;
+4. Navigate to ~/demos/portfolio/stock-trading-service/ and run **gradle installDist**;
 5. Navigate to /stock-trading-service/build/install/stock-trading-service/bin. Here you can find for Linux Distribuition/MacOS a script "stock-trading-service" and for Windows a bat "stock-trading-service.bat";
 6. Run the script/bat that fits your environmnet by doing "./stock-trading-service" or "stock-trading-service.bat";
-7. If your ActiveMQ is *NOT* listening to tcp://localhost:61616 you will have to give the script as the first parameter the URL that your ActiveMQ is listening to ex: "./stock-trading-service tcp://{ACTIVEMQ.IP}:{ACTIVEMQ.PORT}" .Now the ticker that fetched and post the stock data has successfully started!;
+7. If your ActiveMQ is **NOT** listening to tcp://localhost:61616 you will have to give the script as the first parameter the URL that your ActiveMQ is listening to ex: "./stock-trading-service tcp://{ACTIVEMQ.IP}:{ACTIVEMQ.PORT}" .Now the ticker that fetched and post the stock data has successfully started!;
 8. Navigate to ~/demos/portfolio/portfolio-web/ and run *npm install* to resolve needed dependencie;
-9. If your gateway is *NOT* accepting JMS connections on "ws://localhost:8000/jms" you will have to edit this file: ~/demos/portfolio/portfolio-web/server.js. You have to edit line 3 : "uri: 'localhost' to url: '"'{GATEWAY.IP}';
+9. If your gateway is **NOT** accepting JMS connections on "ws://localhost:8000/jms" you will have to edit this file: ~/demos/portfolio/portfolio-web/server.js. You have to edit line 3 : "uri: 'localhost' to url: '"'{GATEWAY.IP}';
 10. Now in ~/demos/portfolio/portfolio-web/ run "node server.js";
 11. Now you are done and you can access either localhost:3000 or {GATEWAY.IP}:3000!
  

--- a/portfolio/logs/events.log
+++ b/portfolio/logs/events.log
@@ -1,0 +1,53 @@
+Getting initial stock values...
+Ready to run...
+* ======================================
+* Kaazing Stock Portfolio Demo
+* Connecting on tcp://localhost:61616
+* ======================================
+Sending: WireFormatInfo { version=11, properties={TcpNoDelayEnabled=true, SizePrefixDisabled=false, CacheSize=1024, StackTraceEnabled=true, CacheEnabled=true, TightEncodingEnabled=true, MaxFrameSize=9223372036854775807, Host=localhost, MaxInactivityDuration=30000, MaxInactivityDurationInitalDelay=10000}, magic=[A,c,t,i,v,e,M,Q]}
+Using min of local: WireFormatInfo { version=11, properties={TcpNoDelayEnabled=true, SizePrefixDisabled=false, CacheSize=1024, StackTraceEnabled=true, CacheEnabled=true, TightEncodingEnabled=true, MaxFrameSize=9223372036854775807, Host=localhost, MaxInactivityDuration=30000, MaxInactivityDurationInitalDelay=10000}, magic=[A,c,t,i,v,e,M,Q]} and remote: WireFormatInfo { version=11, properties={TcpNoDelayEnabled=true, SizePrefixDisabled=false, CacheSize=1024, StackTraceEnabled=true, CacheEnabled=true, TightEncodingEnabled=true, MaxFrameSize=104857600, MaxInactivityDuration=30000, MaxInactivityDurationInitalDelay=10000}, magic=[A,c,t,i,v,e,M,Q]}
+Received WireFormat: WireFormatInfo { version=11, properties={TcpNoDelayEnabled=true, SizePrefixDisabled=false, CacheSize=1024, StackTraceEnabled=true, CacheEnabled=true, TightEncodingEnabled=true, MaxFrameSize=104857600, MaxInactivityDuration=30000, MaxInactivityDurationInitalDelay=10000}, magic=[A,c,t,i,v,e,M,Q]}
+tcp://localhost/127.0.0.1:61616@54084 before negotiation: OpenWireFormat{version=11, cacheEnabled=false, stackTraceEnabled=false, tightEncodingEnabled=false, sizePrefixDisabled=false, maxFrameSize=9223372036854775807}
+tcp://localhost/127.0.0.1:61616@54084 after negotiation: OpenWireFormat{version=11, cacheEnabled=true, stackTraceEnabled=true, tightEncodingEnabled=true, sizePrefixDisabled=false, maxFrameSize=104857600}
+Resetting the value of 3m Co based on the min/max.
+Resetting the value of 3m Co based on the min/max.
+Resetting the value of 3m Co based on the min/max.
+Resetting the value of 3m Co based on the min/max.
+Resetting the value of 3m Co based on the min/max.
+Resetting the value of 3m Co based on the min/max.
+Resetting the value of 3m Co based on the min/max.
+Resetting the value of 3m Co based on the min/max.
+Resetting the value of International Business Machines based on the min/max.
+Resetting the value of International Business Machines based on the min/max.
+Resetting the value of Hewlett-Packard Co. based on the counter.
+WriteChecker: 10000ms elapsed since last write check.
+Resetting the value of International Business Machines based on the min/max.
+Resetting the value of International Business Machines based on the min/max.
+Resetting the value of International Business Machines based on the min/max.
+Initialized TaskRunnerFactory[ActiveMQ Session Task] using ExecutorService: java.util.concurrent.ThreadPoolExecutor@612f17f[Running, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 0]
+WriteChecker: 10000ms elapsed since last write check.
+Resetting the value of Verizon Communications based on the counter.
+30000ms elapsed since last read check.
+WriteChecker: 10000ms elapsed since last write check.
+Resetting the value of Boeing Co. based on the counter.
+WriteChecker: 10000ms elapsed since last write check.
+Resetting the value of Verizon Communications based on the counter.
+WriteChecker: 10000ms elapsed since last write check.
+Resetting the value of Verizon Communications based on the counter.
+30000ms elapsed since last read check.
+WriteChecker: 10000ms elapsed since last write check.
+Resetting the value of Verizon Communications based on the counter.
+WriteChecker: 10000ms elapsed since last write check.
+Resetting the value of Microsoft Corporation based on the counter.
+WriteChecker: 10000ms elapsed since last write check.
+Resetting the value of Boeing Co. based on the min/max.
+Resetting the value of Wal-Mart Stores, Inc. based on the counter.
+30000ms elapsed since last read check.
+WriteChecker: 10000ms elapsed since last write check.
+Resetting the value of Hewlett-Packard Co. based on the counter.
+WriteChecker: 10001ms elapsed since last write check.
+WriteChecker: 10000ms elapsed since last write check.
+Resetting the value of AT&T Inc. based on the counter.
+30000ms elapsed since last read check.
+WriteChecker: 10000ms elapsed since last write check.
+Resetting the value of McDonald's Corporation based on the counter.

--- a/portfolio/portfolio-web/index.html
+++ b/portfolio/portfolio-web/index.html
@@ -7,10 +7,10 @@
 		<link rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.css">
 		<link rel="stylesheet" id="kaazing-css" href="//kaazing.com/wp-content/themes/kaazing/assets/css/kaazing.min.css?ver=0.1.0" type="text/css" media="all">
 		<link rel="stylesheet" href="css/app.css">
+
 		<script src="node_modules/angular/angular.js"></script>
 		<script src="node_modules/kaazing-javascript-gateway-client/WebSocket.js"></script>
 		<script src="node_modules/kaazing-javascript-jms-client/JmsClient.js"></script>
-
 		<script src="js/app.js"></script>
 		<script>
 			var topicName = "/topic/portfolioStock";

--- a/portfolio/portfolio-web/js/app.js
+++ b/portfolio/portfolio-web/js/app.js
@@ -9,8 +9,9 @@ angular.module("portfolio-demo", [])
 			url: "ws://localhost:8000/jms",
 			topicName:"/topic/portfolioStock"
 		}
+		console.log("URL" + $location.host());
 		if ($location.host()!="localhost"){
-			$scope.connectionInfo.url="wss://"+$location.host()+"/jms";
+			$scope.connectionInfo.url="ws://"+$location.host()+":8000/jms";
 		}
 		$scope.stockArray=new Array();
 		$scope.stocks=[

--- a/portfolio/portfolio-web/package.json
+++ b/portfolio/portfolio-web/package.json
@@ -17,6 +17,7 @@
   "author": "Kaazing Corporation",
   "license": "MIT",
   "dependencies": {
+    "express": "^4.13.4",
     "angular": "^1.5.7",
     "bootstrap": "^3.3.6",
     "kaazing-javascript-jms-client": "^4.4.2"

--- a/portfolio/portfolio-web/server.js
+++ b/portfolio/portfolio-web/server.js
@@ -1,0 +1,12 @@
+// Server code run with node.js
+var express = require('express');
+var uri = 'localhost'
+var port = 3000;
+var app = express();
+var http = require('http').Server(app);
+app.use(express.static(__dirname + 'node_modules'));
+app.use(express.static(__dirname));
+
+http.listen(port, uri, function () {
+    console.log('listening on ' +  uri+ ':3000');
+});

--- a/portfolio/portfolio-web/server.js
+++ b/portfolio/portfolio-web/server.js
@@ -1,6 +1,6 @@
 // Server code run with node.js
 var express = require('express');
-var uri = 'localhost'
+var uri = 'localhost';
 var port = 3000;
 var app = express();
 var http = require('http').Server(app);


### PR DESCRIPTION
Portfolio demo was not working correctly and was not documented, added a few changes to be consistent with other JS demos and added instruction for correctly building and running the demo

Client came in with a problem running the portfolio demo on his machine. The documentation was lacking for the portfolio demo, I added step by step instruction for running the demo.
Also in /demos/portfolio/portfolio-web/js/app.js there was a problem with `$location.host()`, if we tried to run the demo just by using index.html in a browser,  `$location.host()` would be equal to "" and the demo would try to connect to "ws:///jms", it would never try to connect to ws://localhost:8000/jms" because we check to see if  `$location.host()!='localhost' which was always true and the demo would not work.
To be consistent with the other jms/ws demos and to rectify the problem stated above I added a `server.js` which will start a local web server either on 'localhost:3000' or if the user edits it on '{IP}:3000', now the angular function `$location.host()` will resolve to localhost or the {IP} from the local web server. 
